### PR TITLE
Prevent theme switching with no delay

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.lua]
+indent_style = space
+indent_size = 2

--- a/lua/circadian/init.lua
+++ b/lua/circadian/init.lua
@@ -35,11 +35,12 @@ local function set_theme(opts)
       need_reset = true
     end
     vim.notify(
-      "Circadian: day detected (" .. day.colorscheme .. " / " .. day.background ..  ")",
+      "Circadian: day detected (" .. day.colorscheme .. " / " .. day.background .. ")",
       vim.log.levels.INFO,
-    {title = "Circadian"})
+      { title = "Circadian" }
+    )
     if need_reset then
-        vim.cmd("syntax reset")
+      vim.cmd("syntax reset")
     end
   else
     next_time = rise
@@ -53,34 +54,32 @@ local function set_theme(opts)
       need_reset = true
     end
     vim.notify(
-      "Circadian: night detected (" .. night.colorscheme .. " / " .. night.background ..  ")",
+      "Circadian: night detected (" .. night.colorscheme .. " / " .. night.background .. ")",
       vim.log.levels.INFO,
-    {title = "Circadian"})
-    if need_reset then vim.cmd("syntax reset") end
+      { title = "Circadian" }
+    )
+    if need_reset then
+      vim.cmd("syntax reset")
+    end
   end
 
-  local timer = vim.loop.new_timer()
   local delay = next_time - os.time()
   -- Detecting when next_time is in the past
   -- Looping an extra day like that is likely to be 2/3 minutes off though
   if delay < 0 then
     delay = delay + 86400
+  elseif delay == 0 then
+    delay = 1
   end
   vim.notify(
-    "Circadian: next change planned at " .. os.date('%H:%M:%S', next_time) .. " (in " .. delay .. " seconds)",
+    "Circadian: next change planned at " .. os.date("%H:%M:%S", next_time) .. " (in " .. delay .. " seconds)",
     vim.log.levels.DEBUG,
-  {title = "Circadian"})
+    { title = "Circadian" }
+  )
 
-  timer:start(delay,
-              0,
-              function ()
-                timer:stop()
-                timer:close()
-                vim.schedule_wrap(function()
-                  set_theme(opts)
-                end)
-              end)
-  return timer
+  return vim.defer_fn(function()
+    set_theme(opts)
+  end, delay * 1000)
 end
 
 function M.setup(opts)
@@ -91,11 +90,9 @@ function M.stop()
   if timer then
     timer:stop()
     timer:close()
-    vim.notify("Call circadian.setup again with the arguments to restart", vim.log.levels.INFO,
-    {title = "Circadian"})
+    vim.notify("Call circadian.setup again with the arguments to restart", vim.log.levels.INFO, { title = "Circadian" })
   else
-    vim.notify("Circadian is not running now", vim.log.levels.WARN,
-    {title = "Circadian"})
+    vim.notify("Circadian is not running now", vim.log.levels.WARN, { title = "Circadian" })
   end
 end
 

--- a/lua/circadian/init.lua
+++ b/lua/circadian/init.lua
@@ -6,61 +6,48 @@ local M = {}
 
 local lustrous = require("circadian.lustrous")
 
-local timer
-
 local function get_timezone_offset_hours()
   local now = os.time()
   return (os.difftime(now, os.time(os.date("!*t", now))) / 3600.0)
 end
 
-local function set_theme(opts)
-  local day = opts.day or { background = "light", colorscheme = nil }
-  local night = opts.night or { background = "dark", colorscheme = nil }
+local timer
+
+local function set_theme(name, theme)
+  local need_reset = false
+  if theme.background then
+    vim.o.background = theme.background
+    need_reset = true
+  end
+  if theme.colorscheme then
+    vim.cmd("colorscheme " .. theme.colorscheme)
+    need_reset = true
+  end
+  if need_reset then
+    vim.cmd("syntax reset")
+  end
+  vim.notify(
+    "Circadian: " .. name .. " detected (" .. theme.colorscheme .. " / " .. theme.background .. ")",
+    vim.log.levels.INFO,
+    { title = "Circadian" }
+  )
+end
+
+local function main(opts)
+  local default = {
+    day = { background = "light", colorscheme = nil },
+    night = { background = "dark", colorscheme = nil },
+  }
   local lat = opts.lat or 48.8567879
   local lon = opts.lon or 2.3510768
 
   local current, rise, set = lustrous.get_time({ lat = lat, lon = lon, offset = get_timezone_offset_hours() })
-
   local next_time = rise
-
+  set_theme(current, opts[current] or default[current])
   if current == "day" then
     next_time = set
-    local need_reset = false
-    if day.background then
-      vim.o.background = day.background
-      need_reset = true
-    end
-    if day.colorscheme then
-      vim.cmd("colorscheme " .. day.colorscheme)
-      need_reset = true
-    end
-    vim.notify(
-      "Circadian: day detected (" .. day.colorscheme .. " / " .. day.background .. ")",
-      vim.log.levels.INFO,
-      { title = "Circadian" }
-    )
-    if need_reset then
-      vim.cmd("syntax reset")
-    end
   else
     next_time = rise
-    local need_reset = false
-    if night.background then
-      vim.o.background = night.background
-      need_reset = true
-    end
-    if night.colorscheme then
-      vim.cmd("colorscheme " .. night.colorscheme)
-      need_reset = true
-    end
-    vim.notify(
-      "Circadian: night detected (" .. night.colorscheme .. " / " .. night.background .. ")",
-      vim.log.levels.INFO,
-      { title = "Circadian" }
-    )
-    if need_reset then
-      vim.cmd("syntax reset")
-    end
   end
 
   local delay = next_time - os.time()
@@ -78,12 +65,12 @@ local function set_theme(opts)
   )
 
   return vim.defer_fn(function()
-    set_theme(opts)
+    main(opts)
   end, delay * 1000)
 end
 
 function M.setup(opts)
-  timer = set_theme(opts)
+  timer = main(opts)
 end
 
 function M.stop()


### PR DESCRIPTION
I was seeing an issue right along the boundary of sunrise/sunset where it would constantly notify that the theme had been changed with an extremely short delay and would continue like this until I had restart nvim. While investigating this, I also noticed that the timers are in ms, but this was being calculated in seconds.

I converted the vim.loop timer to `vim.defer_fn`. `vim.loop` as been deprecated in favor of `vim.uv` anyways, and `vim.defer_fn` is more aligned with what is trying to be done here (one-off timers being created at varying frequency).

I also added an `.editorconfig` file because lua_ls was really fighting with the existing formatting, and I split the control flow into two separate functions: one that manages the timer and one that handles the theme.

I've let an nvim window run for about 24 hours now without seeing any of the errors or behavior I was seeing previously and intend to let it run for a few more days.

I know I've done more than the initial change, so I did break this into individual commits here that I can PR independently if desired!